### PR TITLE
feat: Define eip1559 feature flag

### DIFF
--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -64,6 +64,7 @@ rand.workspace = true
 [features]
 celo = ["legacy"] # celo support extends the transaction format with extra fields
 legacy = []
+eip1559 = []
 macros = ["syn", "cargo_metadata", "once_cell"]
 optimism = []
 

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -86,6 +86,7 @@ solc-tests = ["ethers-solc?/tests"]
 # Deprecated
 abigen-offline = ["abigen"]
 eip712 = []
+eip1559 = ["ethers-core/eip1559"]
 ethers-solc = ["solc"]
 solc-sha2-asm = []
 


### PR DESCRIPTION
Adds the `eip1559` feature flag that was previously missing.

The `base-snipers` project, which depends on a git version of this ethers-rs fork, requires the `eip1559` feature. This commit introduces the necessary definitions in `ethers-core/Cargo.toml` and `ethers/Cargo.toml`.

1.  In `ethers-core/Cargo.toml`:
    - Added `eip1559 = []` to the `[features]` section.

2.  In `ethers/Cargo.toml`:
    - Added `eip1559 = ["ethers-core/eip1559"]` to the `[features]` section, linking it to the corresponding feature in `ethers-core`.

This change allows downstream crates to enable eip1559-specific functionality via the `eip1559` feature flag when depending on this fork of ethers-rs.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
